### PR TITLE
Add document chunking and chunk search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ This repository contains `localindex`, a Rust CLI for indexing and searching loc
 - `localindex.toml` – sample configuration
 - Content extraction sidecar configured via `extractor_url` populates a `documents` table
 - Tantivy-based BM25 index built under `tantivy_index`
+- Chunk index stored under `tantivy_index/chunks`
 
 ## Standards
 - Rust 1.75+

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ Example JSON output:
 {"results":[{"path":"/data/a/msa.pdf","score":12.3,"file_id":42,"mtime":"2025-07-05T12:43:11Z"}]}
 ```
 
+## Chunking and chunk search
+
+During indexing, documents are split into overlapping chunks which are stored in a `chunks`
+table and indexed separately under `tantivy_index/chunks`. Queries can target chunks instead
+of whole documents by passing `--chunks`:
+
+```bash
+localindex query --tantivy-index state/idx --db state/catalog.db \
+  --mode keyword --chunks "résiliation pour faute grave"
+```
+
+Example chunk result:
+
+```json
+{"results":[{"path":"/data/a/msa.pdf","score":9.8,"chunk_id":"abcd..","start_byte":182340,"end_byte":183912}]}
+```
+
 ## Building
 
 ```bash

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -1,0 +1,56 @@
+use anyhow::Result;
+use blake3::Hasher;
+use rusqlite::{params, Connection};
+
+/// Chunk all active documents in the database.
+pub fn chunk_all(conn: &Connection) -> Result<()> {
+    let mut stmt = conn.prepare(
+        "SELECT f.id, f.realpath, IFNULL(d.content_txt,'' ) FROM files f \
+         JOIN documents d ON f.id=d.file_id WHERE f.status='active'",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (file_id, path, content) = row?;
+        chunk_document(conn, file_id, &path, &content)?;
+    }
+    Ok(())
+}
+
+fn chunk_document(conn: &Connection, file_id: i64, path: &str, content: &str) -> Result<()> {
+    conn.execute("DELETE FROM chunks WHERE file_id=?1", params![file_id])?;
+    let chunk_size = 2000; // bytes
+    let overlap = 200; // bytes
+    let mut start = 0;
+    let len = content.len();
+    while start < len {
+        let mut end = std::cmp::min(start + chunk_size, len);
+        while end < len && !content.is_char_boundary(end) {
+            end += 1;
+        }
+        let text = &content[start..end];
+        let token_count = text.split_whitespace().count() as i64;
+        let mut hasher = Hasher::new();
+        hasher.update(path.as_bytes());
+        hasher.update(start.to_string().as_bytes());
+        hasher.update(end.to_string().as_bytes());
+        let chunk_id = hasher.finalize().to_hex().to_string();
+        conn.execute(
+            "INSERT INTO chunks (file_id, chunk_id, start_byte, end_byte, token_count, text) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![file_id, chunk_id, start as i64, end as i64, token_count, text],
+        )?;
+        if end == len {
+            break;
+        }
+        start = end.saturating_sub(overlap);
+        while start > 0 && !content.is_char_boundary(start) {
+            start += 1;
+        }
+    }
+    Ok(())
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -43,6 +43,18 @@ pub fn open(path: &Utf8Path) -> Result<Connection> {
           ocr_applied INTEGER NOT NULL DEFAULT 0,
           updated_ts INTEGER NOT NULL
         );
+        CREATE TABLE IF NOT EXISTS chunks (
+          file_id INTEGER NOT NULL,
+          chunk_id TEXT PRIMARY KEY,
+          start_byte INTEGER NOT NULL,
+          end_byte INTEGER NOT NULL,
+          page_from INTEGER,
+          page_to INTEGER,
+          section_path TEXT,
+          token_count INTEGER,
+          text BLOB NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS chunks_file ON chunks(file_id);
         "#,
     )?;
     Ok(conn)

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -9,7 +9,7 @@ use tantivy::schema::Value;
 use tantivy::{Index, TantivyDocument};
 
 use crate::config::Config;
-use crate::index::{self, IndexFields};
+use crate::index::{self, ChunkFields, IndexFields};
 
 #[derive(Serialize)]
 pub struct SearchHit {
@@ -22,6 +22,20 @@ pub struct SearchHit {
 #[derive(Serialize)]
 pub struct SearchResults {
     pub results: Vec<SearchHit>,
+}
+
+#[derive(Serialize)]
+pub struct ChunkSearchHit {
+    pub path: String,
+    pub score: f32,
+    pub chunk_id: String,
+    pub start_byte: i64,
+    pub end_byte: i64,
+}
+
+#[derive(Serialize)]
+pub struct ChunkSearchResults {
+    pub results: Vec<ChunkSearchHit>,
 }
 
 /// Execute a keyword query against the index and return the top K results.
@@ -69,6 +83,53 @@ pub fn keyword(cfg: &Config, query: &str, top_k: usize) -> Result<SearchResults>
     Ok(SearchResults { results: hits })
 }
 
+/// Execute a keyword query against the chunk index and return the top K results.
+pub fn keyword_chunks(cfg: &Config, query: &str, top_k: usize) -> Result<ChunkSearchResults> {
+    let index_dir = cfg.tantivy_index.join("chunks");
+    let index = Index::open_in_dir(index_dir.as_std_path())?;
+    index::register_tokenizers(&index);
+    let schema = index.schema();
+    let fields = ChunkFields::from_schema(&schema);
+    let reader = index.reader()?;
+    let searcher = reader.searcher();
+    let mut parser =
+        QueryParser::for_index(&index, vec![fields.chunk_text_en, fields.chunk_text_fr]);
+    parser.set_field_boost(fields.chunk_text_en, 1.0);
+    parser.set_field_boost(fields.chunk_text_fr, 1.0);
+    let q = parser.parse_query(query)?;
+    let top_docs = searcher.search(&q, &TopDocs::with_limit(top_k))?;
+    let mut hits = Vec::new();
+    for (score, addr) in top_docs {
+        let retrieved: TantivyDocument = searcher.doc(addr)?;
+        let path = retrieved
+            .get_first(fields.path)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let chunk_id = retrieved
+            .get_first(fields.chunk_id)
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let start_byte = retrieved
+            .get_first(fields.start_byte)
+            .and_then(|v| v.as_i64())
+            .unwrap_or_default();
+        let end_byte = retrieved
+            .get_first(fields.end_byte)
+            .and_then(|v| v.as_i64())
+            .unwrap_or_default();
+        hits.push(ChunkSearchHit {
+            path,
+            score,
+            chunk_id,
+            start_byte,
+            end_byte,
+        });
+    }
+    Ok(ChunkSearchResults { results: hits })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +138,7 @@ mod tests {
 
     use crate::config::{Config, EmbeddingConfig};
     use crate::db;
+    use rusqlite::params;
 
     #[test]
     fn keyword_search_returns_hit() -> Result<()> {
@@ -108,6 +170,41 @@ mod tests {
         index::reindex_all(&cfg)?;
         let res = keyword(&cfg, "hello", 10)?;
         assert_eq!(res.results.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn keyword_chunk_search_returns_hit() -> Result<()> {
+        let tmp = tempdir()?;
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let db_path = root.join("catalog.db");
+        let idx_path = root.join("idx");
+        let cfg = Config {
+            db: db_path.clone(),
+            tantivy_index: idx_path.clone(),
+            roots: vec![],
+            include: vec![],
+            exclude: vec![],
+            max_file_size_mb: 200,
+            follow_symlinks: false,
+            commit_interval_secs: 45,
+            guard_interval_secs: 180,
+            default_language: "en".into(),
+            extractor_url: String::new(),
+            embedding: EmbeddingConfig {
+                provider: "disabled".into(),
+            },
+        };
+
+        let conn = db::open(&db_path)?;
+        conn.execute("INSERT INTO files (id, realpath, size, mtime_ns, status, created_ts, updated_ts) VALUES (1,'/tmp/a.txt',1,0,'active',0,0)", [])?;
+        let long_text = "hello world".repeat(100);
+        conn.execute("INSERT INTO documents (file_id, extractor, extractor_version, lang, page_count, content_md, content_txt, ocr_applied, updated_ts) VALUES (1,'doc','v','en',1,'',?1,0,0)",
+            params![long_text])?;
+
+        index::reindex_all(&cfg)?;
+        let res = keyword_chunks(&cfg, "hello", 10)?;
+        assert!(!res.results.is_empty());
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Add database `chunks` table and chunking module
- Index document chunks and create a chunk Tantivy index
- Support `--chunks` flag in query and oneshot commands for chunk search

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a96b8fb534832cbae636402c75f7e7