### PR TITLE
ci: publish binaries on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,99 @@
+name: release
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os_name: linux
+            ext: ""
+          - os: macos-latest
+            os_name: macos
+            ext: ""
+          - os: windows-latest
+            os_name: windows
+            ext: ".exe"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version metadata
+        id: meta
+        shell: bash
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+            DESCRIBE="${GITHUB_REF_NAME}"
+          else
+            DESCRIBE="$(git describe --tags --always --dirty)"
+            VERSION="${DESCRIBE}"
+          fi
+          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
+          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
+          echo "date=${DATE}"         >> $GITHUB_OUTPUT
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build
+        env:
+          LOCALINDEX_VERSION: ${{ steps.meta.outputs.version }}
+        run: cargo build --release
+
+      - name: Package
+        id: pkg
+        shell: bash
+        run: |
+          ARCH=x86_64
+          OS=${{ matrix.os_name }}
+          NAME="localindex_${OS}_${ARCH}_${{ steps.meta.outputs.version }}"
+          mkdir -p "pkg/$NAME"
+          cp LICENSE README.md target/release/localindex${{ matrix.ext }} "pkg/$NAME"/
+          echo "dir=pkg/$NAME" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.pkg.outputs.name }}
+          path: ${{ steps.pkg.outputs.dir }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dl
+      - name: Repack & checksums
+        shell: bash
+        run: |
+          mkdir -p out
+          for d in dl/*; do
+            base=$(basename "$d")
+            if [[ "$base" == *windows* ]]; then
+              (cd dl && zip -r -9 "../out/${base}.zip" "$base")
+            else
+              tar -C dl -czf "out/${base}.tar.gz" "$base"
+            fi
+          done
+          (cd out && sha256sum * > SHA256SUMS.txt)
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            out/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,71 @@
+permissions:
+  contents: read
+name: snapshot
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os_name: linux
+            ext: ""
+          - os: macos-latest
+            os_name: macos
+            ext: ""
+          - os: windows-latest
+            os_name: windows
+            ext: ".exe"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute version metadata
+        id: meta
+        shell: bash
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME}"
+            DESCRIBE="${GITHUB_REF_NAME}"
+          else
+            DESCRIBE="$(git describe --tags --always --dirty)"
+            VERSION="${DESCRIBE}"
+          fi
+          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
+          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
+          echo "date=${DATE}"         >> $GITHUB_OUTPUT
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Build
+        env:
+          LOCALINDEX_VERSION: ${{ steps.meta.outputs.version }}
+        run: cargo build --release
+
+      - name: Package
+        id: pkg
+        shell: bash
+        run: |
+          ARCH=x86_64
+          OS=${{ matrix.os_name }}
+          NAME="localindex_${OS}_${ARCH}_${{ steps.meta.outputs.describe }}"
+          mkdir -p "pkg/$NAME"
+          cp LICENSE README.md target/release/localindex${{ matrix.ext }} "pkg/$NAME"/
+          echo "file=pkg/$NAME" >> $GITHUB_OUTPUT
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.pkg.outputs.name }}
+          path: ${{ steps.pkg.outputs.file }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This repository contains `localindex`, a Rust CLI for indexing and searching loc
 - `src/` – Rust source code and module scaffolding
 - `docs/` – project documentation
 - `examples/` – example configurations or snippets
+- `.github/workflows/` – CI and release automation
 - `tools/` – helper scripts and container files
 - `localindex.toml` – sample configuration
 - Content extraction sidecar configured via `extractor_url` populates a `documents` table
@@ -26,6 +27,9 @@ cargo fmt --all
 cargo check
 cargo test
 ```
+
+Snapshot artifacts for `main` come from `.github/workflows/snapshot.yml`.
+Releases are published with `.github/workflows/release.yml`, which builds and uploads binaries for Linux, macOS, and Windows when a tag is pushed.
 
 ## Documentation
 Keep documentation current. Update `README.md` and this `AGENTS.md` whenever project behavior or structure changes.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ localindex query --tantivy-index state/idx --db state/catalog.db \
 cargo build
 ```
 
+## Releases
+
+Prebuilt binaries for Linux, macOS, and Windows are available on the [GitHub Releases](https://github.com/gaspardpetit/localindex/releases) page.
+These binaries embed the release tag; verify with `localindex --version`.
+
+Snapshot artifacts for the `main` branch are published by the `snapshot` workflow.
+
 ## Help
 
 ```bash

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let default_version = env!("CARGO_PKG_VERSION");
+    let version =
+        std::env::var("LOCALINDEX_VERSION").unwrap_or_else(|_| default_version.to_string());
+    println!("cargo:rustc-env=LOCALINDEX_VERSION={}", version);
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser, Debug)]
-#[command(name = "localindex", version, about = "Local document indexer")]
+#[command(name = "localindex", version = env!("LOCALINDEX_VERSION"), about = "Local document indexer")]
 pub struct Cli {
     #[arg(
         long,


### PR DESCRIPTION
## Summary
- embed release metadata into binaries and surface with `--version`
- publish snapshot artifacts from `main` and tagged release assets
- document snapshot workflow and versioned binaries

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a97165695c832c8b86eaf46e37a2a8