### PR TITLE
feat: add Dockerfile and usage examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository contains `localindex`, a Rust CLI for indexing and searching loc
 - `examples/` – example configurations or snippets
 - `.github/workflows/` – CI and release automation
 - `tools/` – helper scripts and container files
+- `Dockerfile` – container image for running the CLI
 - `localindex.toml` – sample configuration
 - Content extraction uses a configurable command (`extractor_cmd`, default `docling --to txt`) to populate a `documents` table; plain text files are read directly
 - Tantivy-based BM25 index built under `tantivy_index`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+
+## Build stage
+FROM rust:1.75 as builder
+WORKDIR /usr/src/localindex
+COPY . .
+RUN cargo build --release
+
+## Runtime stage
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Directory where data will be mounted
+WORKDIR /data
+
+# Copy compiled binary
+COPY --from=builder /usr/src/localindex/target/release/localindex /usr/local/bin/localindex
+
+ENTRYPOINT ["localindex"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ These binaries embed the release tag; verify with `localindex --version`.
 
 Snapshot artifacts for the `main` branch are published by the `snapshot` workflow.
 
+## Docker
+
+A published container image can run `localindex` against a mounted directory. Bind a host path to `/data` and pass your config.
+
+### Index and query
+
+```bash
+docker run --rm -v "$(pwd)":/data ghcr.io/gaspardpetit/localindex:latest index --config /data/localindex.toml
+docker run --rm -v "$(pwd)":/data ghcr.io/gaspardpetit/localindex:latest query --config /data/localindex.toml --mode keyword "project timeline"
+```
+
+### Watch and exec
+
+```bash
+docker run -d --name li -v "$(pwd)":/data ghcr.io/gaspardpetit/localindex:latest watch --config /data/localindex.toml
+docker exec li localindex query --config /data/localindex.toml --mode keyword "project timeline"
+```
+
+
 ## Help
 
 ```bash


### PR DESCRIPTION
## Summary
- build localindex into a runnable container image
- document docker workflows for indexing and watch mode
- note Dockerfile in project structure

## Testing
- `cargo fmt --all`
- `cargo check` *(fails: Failed to GET `https://cdn.pyke.io/...`: CONNECT proxy failed: proxy server responded 403/403)*
- `cargo test` *(fails: Failed to GET `https://cdn.pyke.io/...`: CONNECT proxy failed: proxy server responded 403/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e285ffdc832ca22ce79967dee5d6