### PR TITLE
Ensure lockfile path exists and improve error context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
   `snowflake/snowflake-arctic-embed-xs` when `EMBEDDING_MODEL` is set.
 - `watch` listens for SIGINT and SIGTERM to exit cleanly.
 
+- Runtime state (e.g. the indexing lockfile) lives under `.findx/state`.
+
 ## Standards
 - Rust 1.88+
 - Format code with `cargo fmt --all`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ findx index
 findx query rust documentation
 ```
 
-The commands above index the current directory and place all data under `.findx/`. Query defaults to a hybrid search mode.
+The commands above index the current directory and place all data under `.findx/`, creating the directory if it does not exist. Runtime state such as the lockfile lives under `.findx/state`. Query defaults to a hybrid search mode.
 
 ## Dependencies
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::Read;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
@@ -196,7 +196,7 @@ fn build_glob_set(patterns: &[String]) -> Result<GlobSet> {
 }
 
 fn hash_file(path: &Utf8Path) -> Result<String> {
-    let mut file = File::open(path)?;
+    let mut file = File::open(path).with_context(|| format!("open file for hashing {path}"))?;
     let mut hasher = Xxh3::new();
     let mut buf = [0u8; 8192];
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
 
     let _lock = match &cli.command {
         Command::Index(_) | Command::Watch(_) | Command::Oneshot(_) => {
-            let lock_path = Utf8PathBuf::from("state/index.lock");
+            let lock_path = Utf8PathBuf::from(".findx/state/index.lock");
             Some(Lockfile::acquire(lock_path)?)
         }
         _ => None,

--- a/src/util/lock.rs
+++ b/src/util/lock.rs
@@ -4,13 +4,18 @@ use std::process;
 
 use camino::Utf8PathBuf;
 use thiserror::Error;
+use tracing::debug;
 
 #[derive(Debug, Error)]
 pub enum LockError {
     #[error("lockfile exists at {0}")]
     Exists(Utf8PathBuf),
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
+    #[error("could not create lockfile at {path}: {source}")]
+    Io {
+        path: Utf8PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
 #[derive(Debug)]
@@ -20,17 +25,27 @@ pub struct Lockfile {
 
 impl Lockfile {
     pub fn acquire(path: Utf8PathBuf) -> Result<Self, LockError> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|e| LockError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+        debug!(%path, "acquiring lockfile");
         match OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(path.as_std_path())
         {
             Ok(mut f) => {
-                writeln!(f, "{}", process::id())?;
+                writeln!(f, "{}", process::id()).map_err(|e| LockError::Io {
+                    path: path.clone(),
+                    source: e,
+                })?;
                 Ok(Self { path })
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(LockError::Exists(path)),
-            Err(e) => Err(LockError::Io(e)),
+            Err(e) => Err(LockError::Io { path, source: e }),
         }
     }
 }


### PR DESCRIPTION
## Summary
- create `.findx/state` automatically and store the lockfile there
- expand I/O error messages with full paths and add helpful logging
- document runtime state location under `.findx`

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa0277eb4832c9f85336bbadc1fe3