### PR TITLE
feat(embed): move fastembed cache under .findx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - Tantivy-based BM25 index built under `tantivy_index`
 - Chunk index stored under `tantivy_index/chunks`
 - Embeddings stored in SQLite `embeddings` table for semantic search.
-  Local embeddings use the `fastembed` crate by default; set `EMBEDDING_URL`
+  Local embeddings use the `fastembed` crate by default and cache models under
+  `.findx/fastembed_cache`; set `EMBEDDING_URL`
   (and optional `EMBEDDING_API_KEY`) to delegate to an external provider.
   Setting `EMBEDDING_MODEL` to an unsupported value now causes an error rather
   than falling back to the default model.

--- a/README.md
+++ b/README.md
@@ -117,12 +117,13 @@ Example chunk result:
 
 Chunks can be embedded into vectors for multilingual semantic search. When the
 embedding provider is enabled (`embedding.provider = "builtin"`), each chunk is
-encoded and stored in an `embeddings` table. By default `findx` uses a
-Rust native embedder powered by [fastembed](https://crates.io/crates/fastembed)
-and downloads a supported model the first time it runs. You can hint another
-model by setting `EMBEDDING_MODEL` to a name from
-`TextEmbedding::list_supported_models()`. If the requested model is unsupported
-or cannot be downloaded, `findx` returns an error instead of falling back
+  encoded and stored in an `embeddings` table. By default `findx` uses a
+  Rust native embedder powered by [fastembed](https://crates.io/crates/fastembed),
+  caching models under `.findx/fastembed_cache`. It downloads a supported model
+  the first time it runs. You can hint another
+  model by setting `EMBEDDING_MODEL` to a name from
+  `TextEmbedding::list_supported_models()`. If the requested model is unsupported
+  or cannot be downloaded, `findx` returns an error instead of falling back
 to a default embedding model.
 
 Before attempting a network download, `findx` looks for model files under

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -25,13 +25,19 @@ impl LocalEmbedder {
             let parsed = model_name
                 .parse::<EmbeddingModel>()
                 .map_err(|_| anyhow!("unsupported embedding model '{}'", model_name))?;
-            TextEmbedding::try_new(InitOptions::new(parsed).with_show_download_progress(true))
-                .with_context(|| {
-                    format!(
-                        "failed to initialize fastembed TextEmbedding for '{}'",
-                        model_name
-                    )
-                })?
+            let cache_dir = Utf8PathBuf::from(".findx/fastembed_cache");
+            fs::create_dir_all(&cache_dir).context("failed to create fastembed cache directory")?;
+            TextEmbedding::try_new(
+                InitOptions::new(parsed)
+                    .with_cache_dir(cache_dir.into())
+                    .with_show_download_progress(true),
+            )
+            .with_context(|| {
+                format!(
+                    "failed to initialize fastembed TextEmbedding for '{}'",
+                    model_name
+                )
+            })?
         };
         Ok(Self {
             model: Mutex::new(model),


### PR DESCRIPTION
## Summary
- store fastembed models under `.findx/fastembed_cache`
- document new cache location

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa37ceb60832c8f813ceeacb168d8