### PR TITLE
Improve indexing visibility and fix embedding runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - `Dockerfile` – container image for running the CLI
 - `findx.toml` – sample configuration
 - `src/util/dashboard.rs` – terminal dashboard for indexing progress
-- Content extraction uses a configurable command (`extractor_cmd`, default `docling --to txt`) to populate a `documents` table; plain text files are read directly
+- Content extraction uses a configurable command (`extractor_cmd`, default `docling --to text`) to populate a `documents` table; plain text files are read directly
 - Tantivy-based BM25 index built under `tantivy_index`
 - Chunk index stored under `tantivy_index/chunks`
 - Embeddings stored in SQLite `embeddings` table for semantic search.
@@ -23,6 +23,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
   Embedding initialization checks `models/<model_name>/` for local files before
   downloading from Hugging Face. Tests use
   `snowflake/snowflake-arctic-embed-xs` when `EMBEDDING_MODEL` is set.
+ - Indexing progress displays the current file and appends a log at `.findx/index.log` with file statuses, chunk counts, and index size.
 - `watch` listens for SIGINT and SIGTERM to exit cleanly.
 
 ## Standards

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -2789,6 +2790,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 blake3 = "1"
 serde_json = "1"
 fastembed = "5"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"] }
 once_cell = "1"
 ctrlc = "3"
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ follow_symlinks = false
 commit_interval_secs = 45
 guard_interval_secs = 180
 default_language = "auto"
-extractor_cmd = "docling --to txt"
+extractor_cmd = "docling --to text"
 
 [embedding]
 provider = "disabled"
@@ -66,16 +66,19 @@ changes, updating the catalog as files are added, modified, or deleted.
 It listens for `SIGINT` and `SIGTERM` to shut down cleanly.
 
 During indexing, a textual dashboard shows progress for files and chunks
-when running in a terminal. The dashboard is suppressed in non-console
-contexts. Set `LOG_LEVEL` (e.g. `debug`, `info`) to control log
-verbosity.
+when running in a terminal, including the path of the file currently
+being processed. The dashboard is suppressed in non-console contexts.
+Set `LOG_LEVEL` (e.g. `debug`, `info`) to control log verbosity. Each
+run appends a plain text log to `.findx/index.log` with file statuses,
+chunk counts, and the final Tantivy index size.
 
 ## Content extraction
 
 During indexing, `findx` converts documents to plain text using a
 configurable command (`extractor_cmd`). By default it invokes the
-[`docling`](https://github.com/docling) CLI. Basic text formats like
-`.txt` or `.md` are read directly without invoking an external tool.
+[`docling`](https://github.com/docling) CLI with `--to text`. Basic text
+formats like `.txt` or `.md` are read directly without invoking an
+external tool.
 Results are stored in a `documents` table with metadata such as language
 and page counts.
 

--- a/findx.toml
+++ b/findx.toml
@@ -8,7 +8,7 @@ follow_symlinks = false
 commit_interval_secs = 45
 guard_interval_secs = 180
 default_language = "auto"
-extractor_cmd = "docling --to txt"
+extractor_cmd = "docling --to text"
 
 [embedding]
 provider = "disabled"

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,5 +61,5 @@ impl Config {
 }
 
 fn default_extractor_cmd() -> String {
-    "docling --to txt".into()
+    "docling --to text".into()
 }

--- a/src/util/dashboard.rs
+++ b/src/util/dashboard.rs
@@ -21,15 +21,20 @@ impl Dashboard {
             return None;
         }
         let mp = MultiProgress::new();
-        let style = ProgressStyle::with_template("{msg:<12} {wide_bar} {pos}/{len} ({eta})")
-            .unwrap()
-            .progress_chars("##-");
+        let file_style =
+            ProgressStyle::with_template("{prefix:<7} {msg:<40} {wide_bar} {pos}/{len} ({eta})")
+                .unwrap()
+                .progress_chars("##-");
         let files = mp.add(ProgressBar::new(total_files));
-        files.set_style(style.clone());
-        files.set_message("Files");
+        files.set_style(file_style);
+        files.set_prefix("Files");
+        let chunk_style =
+            ProgressStyle::with_template("{prefix:<7} {wide_bar} {pos}/{len} ({eta})")
+                .unwrap()
+                .progress_chars("##-");
         let chunks = mp.add(ProgressBar::new(0));
-        chunks.set_style(style);
-        chunks.set_message("Chunks");
+        chunks.set_style(chunk_style);
+        chunks.set_prefix("Chunks");
         Some(Self {
             mp: Arc::new(mp),
             files,
@@ -40,6 +45,11 @@ impl Dashboard {
     /// Increment the file progress bar.
     pub fn inc_file(&self) {
         self.files.inc(1);
+    }
+
+    /// Update the file progress bar message with the current path.
+    pub fn set_file(&self, path: &str) {
+        self.files.set_message(path.to_string());
     }
 
     /// Mark file progress bar as finished.

--- a/src/util/log.rs
+++ b/src/util/log.rs
@@ -1,0 +1,24 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use anyhow::Result;
+use camino::Utf8PathBuf;
+
+use crate::config::Config;
+
+/// Append a line to the index log under `.findx/index.log`.
+pub fn append(cfg: &Config, msg: &str) -> Result<()> {
+    let base: Utf8PathBuf = cfg
+        .db
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| Utf8PathBuf::from("."));
+    std::fs::create_dir_all(base.as_std_path())?;
+    let log_path = base.join("index.log");
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path.as_std_path())?;
+    writeln!(file, "{}", msg)?;
+    Ok(())
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod dashboard;
 pub mod lock;
+pub mod log;
 pub mod logging;


### PR DESCRIPTION
## Summary
- fix default `docling` extractor command to use `--to text`
- display current file path during indexing and record statuses in `.findx/index.log`
- avoid nested Tokio runtimes by switching embeddings to blocking requests

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa8b32458832ca69cde7e119e1a5e