### PR TITLE
feat(cli): add compact output flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - Format code with `cargo fmt --all`
 - Prefer `Utf8PathBuf` for paths and `tracing` for logs
 - `LOG_LEVEL` environment variable controls log verbosity
+- JSON query results are pretty-printed by default; use `--compact-output` or set `COMPACT_OUTPUT=1` for single-line output
 
 ## Build and Test
 To accept a change, run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 camino = { version = "1", features = ["serde1"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 findx index
 findx query rust documentation
 ```
+By default, query results are printed as human-readable JSON. Pass `--compact-output` or set `COMPACT_OUTPUT=1` for single-line output.
 
 The commands above index the current directory and place all data under `.findx/`, creating the directory if it does not exist. Runtime state such as the lockfile lives under `.findx/state`. Query defaults to a hybrid search mode.
 
@@ -93,7 +94,16 @@ findx query --tantivy-index .findx/idx --db .findx/catalog.db \
 Example JSON output:
 
 ```json
-{"results":[{"path":"./design_spec.pdf","score":12.3,"file_id":42,"mtime":"2025-07-05T12:43:11Z"}]}
+{
+  "results": [
+    {
+      "path": "./design_spec.pdf",
+      "score": 12.3,
+      "file_id": 42,
+      "mtime": "2025-07-05T12:43:11Z"
+    }
+  ]
+}
 ```
 
 ## Chunking and chunk search
@@ -110,7 +120,17 @@ findx query --tantivy-index .findx/idx --db .findx/catalog.db \
 Example chunk result:
 
 ```json
-{"results":[{"path":"./design_spec.pdf","score":9.8,"chunk_id":"abcd..","start_byte":182340,"end_byte":183912}]}
+{
+  "results": [
+    {
+      "path": "./design_spec.pdf",
+      "score": 9.8,
+      "chunk_id": "abcd..",
+      "start_byte": 182340,
+      "end_byte": 183912
+    }
+  ]
+}
 ```
 
 ## Embeddings and semantic search

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,9 @@ pub struct Cli {
     #[arg(long, global = true, value_enum, default_value = "text")]
     pub log_format: LogFormat,
 
+    #[arg(long, global = true, env = "COMPACT_OUTPUT", default_value_t = false)]
+    pub compact_output: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,19 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 use clap::Parser;
 use cli::{Cli, Command, OneshotArgs, WatchArgs};
+use serde::Serialize;
 use util::logging;
 use util::{dashboard, lock::Lockfile};
+
+fn print_json<T: Serialize>(res: &T, compact: bool) -> Result<()> {
+    let json = if compact {
+        serde_json::to_string(res)?
+    } else {
+        serde_json::to_string_pretty(res)?
+    };
+    println!("{}", json);
+    Ok(())
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -102,19 +113,19 @@ async fn main() -> Result<()> {
                 cli::QueryMode::Keyword => {
                     if q.chunks {
                         let res = search::keyword_chunks(&cfg, &q.query, q.top_k)?;
-                        println!("{}", serde_json::to_string(&res)?);
+                        print_json(&res, cli.compact_output)?;
                     } else {
                         let res = search::keyword(&cfg, &q.query, q.top_k)?;
-                        println!("{}", serde_json::to_string(&res)?);
+                        print_json(&res, cli.compact_output)?;
                     }
                 }
                 cli::QueryMode::Semantic => {
                     let res = search::semantic_chunks(&cfg, &q.query, q.top_k)?;
-                    println!("{}", serde_json::to_string(&res)?);
+                    print_json(&res, cli.compact_output)?;
                 }
                 cli::QueryMode::Hybrid => {
                     let res = search::hybrid_chunks(&cfg, &q.query, q.top_k)?;
-                    println!("{}", serde_json::to_string(&res)?);
+                    print_json(&res, cli.compact_output)?;
                 }
             }
         }
@@ -134,19 +145,19 @@ async fn main() -> Result<()> {
                 cli::QueryMode::Keyword => {
                     if o.query.chunks {
                         let res = search::keyword_chunks(&cfg, &o.query.query, o.query.top_k)?;
-                        println!("{}", serde_json::to_string(&res)?);
+                        print_json(&res, cli.compact_output)?;
                     } else {
                         let res = search::keyword(&cfg, &o.query.query, o.query.top_k)?;
-                        println!("{}", serde_json::to_string(&res)?);
+                        print_json(&res, cli.compact_output)?;
                     }
                 }
                 cli::QueryMode::Semantic => {
                     let res = search::semantic_chunks(&cfg, &o.query.query, o.query.top_k)?;
-                    println!("{}", serde_json::to_string(&res)?);
+                    print_json(&res, cli.compact_output)?;
                 }
                 cli::QueryMode::Hybrid => {
                     let res = search::hybrid_chunks(&cfg, &o.query.query, o.query.top_k)?;
-                    println!("{}", serde_json::to_string(&res)?);
+                    print_json(&res, cli.compact_output)?;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- pretty-print query results by default
- add `--compact-output` flag and `COMPACT_OUTPUT` env for single-line JSON
- document output options and enable clap `env` feature

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa999f648832cb3cf349c22c61e90