### PR TITLE
Retry index build on PermissionDenied errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
   downloading from Hugging Face. Tests use
   `snowflake/snowflake-arctic-embed-xs` when `EMBEDDING_MODEL` is set.
  - Indexing progress displays the current file and appends a log at `.findx/index.log` with file statuses, chunk counts, and index size.
+- Transient `PermissionDenied` errors (e.g., Windows file locks) trigger a few automatic retries before failing.
 - `watch` listens for SIGINT and SIGTERM to exit cleanly.
 
 - Runtime state (e.g. the indexing lockfile) lives under `.findx/state`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ being processed. The dashboard is suppressed in non-console contexts.
 Set `LOG_LEVEL` (e.g. `debug`, `info`) to control log verbosity. Each
 run appends a plain text log to `.findx/index.log` with file statuses,
 chunk counts, and the final Tantivy index size.
+Transient `PermissionDenied` errors (such as antivirus scans locking
+Tantivy files on Windows) are detected and the index build automatically
+retries a few times.
 
 ## Content extraction
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -152,7 +152,7 @@ pub fn watch(cfg: &Config) -> Result<()> {
     )?;
     dashboard::init(total_files as u64);
     let dash = dashboard::get();
-    crate::index::reindex_all(cfg, dash)?;
+    crate::index::reindex_all_with_retry(cfg, dash, 3)?;
     let _spinner = dash.map(|d| d.watch_spinner());
 
     let (tx, rx) = channel();

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ async fn main() -> Result<()> {
             )?;
             dashboard::init(total_files as u64);
             let dash = dashboard::get();
-            index::reindex_all(&cfg, dash)?;
+            index::reindex_all_with_retry(&cfg, dash, 3)?;
         }
         Command::Watch(w) => {
             tracing::info!(threads = w.threads, ?cfg, "watch");
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
                 )?;
                 dashboard::init(total_files as u64);
                 let dash = dashboard::get();
-                index::reindex_all(&cfg, dash)?;
+                index::reindex_all_with_retry(&cfg, dash, 3)?;
             }
             tracing::info!(mode = ?q.mode, query = %q.query, top_k = q.top_k, chunks = q.chunks, ?cfg, "query");
             match q.mode {
@@ -140,7 +140,7 @@ async fn main() -> Result<()> {
             )?;
             dashboard::init(total_files as u64);
             let dash = dashboard::get();
-            index::reindex_all(&cfg, dash)?;
+            index::reindex_all_with_retry(&cfg, dash, 3)?;
             match o.query.mode {
                 cli::QueryMode::Keyword => {
                     if o.query.chunks {


### PR DESCRIPTION
## Summary
- retry entire index build when Tantivy returns PermissionDenied
- wire retrying indexer into CLI and watch mode
- document retry behaviour for file locks on Windows

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aabc8e4810832ca219950f9bfb23a8