### PR TITLE
Preserve decimals and dotted acronyms during tokenization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,8 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - Content extraction uses a configurable command (`extractor_cmd`, default `docling --to text`) to populate a `documents` table; plain text files are read directly
 - Tantivy-based BM25 index built under `tantivy_index`
 - Chunk index stored under `tantivy_index/chunks`
+- Tokenization preserves decimals and dotted acronyms so exact section numbers
+  and abbreviations remain searchable.
 - Embeddings stored in SQLite `embeddings` table for semantic search.
   Local embeddings use the `fastembed` crate by default and cache models under
   `.findx/fastembed_cache`; set `EMBEDDING_URL`
@@ -46,6 +48,8 @@ cargo check
 cargo test
 ```
 
+All new or modified features should include unit tests.
+
 Snapshot artifacts for `main` come from `.github/workflows/snapshot.yml`.
 Releases are published with `.github/workflows/release.yml`, which builds and uploads binaries for Linux, macOS, and Windows when a tag is pushed.
 
@@ -56,4 +60,5 @@ Keep documentation current. Update `README.md` and this `AGENTS.md` whenever pro
 - [ ] `cargo fmt --all`
 - [ ] `cargo check`
 - [ ] `cargo test`
+- [ ] New or modified features are covered by unit tests
 - [ ] Docs updated (`README.md`, `AGENTS.md`, others)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ and page counts.
 
 After a scan completes, `findx` builds a BM25 index using Tantivy.
 Documents are indexed into language-specific fields (`body_en`, `body_fr`) based on the
-detected language. Keyword queries return the top matches with scores and metadata:
+detected language. Tokenization preserves decimals and dotted acronyms so references like
+`12.4.1` or `C.c.Q.` remain searchable as single terms. Keyword queries return the top
+matches with scores and metadata:
 
 ```bash
 findx query --tantivy-index .findx/idx --db .findx/catalog.db \


### PR DESCRIPTION
## Summary
- use a RegexTokenizer to keep legal decimals and dotted acronyms intact
- document improved tokenization behavior
- cover tokenizer behavior with unit tests and require unit tests for new features

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab46847d38832c97024391b48c4083