### PR TITLE
Add baseline config and event enums for mirror pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - `tools/` – helper scripts and container files
 - `Dockerfile` – container image for running the CLI
 - `findx.toml` – sample configuration
+- `src/events.rs` – event enum definitions
 - `src/util/dashboard.rs` – terminal dashboard for indexing progress
 - Content extraction uses a configurable command (`extractor_cmd`, default `docling --to text`) to populate a `documents` table; plain text files are read directly. The extractor command is parsed with shell-style rules so arguments may be quoted.
 - Tantivy-based BM25 index built under `tantivy_index`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ extractor_cmd = "docling --to text"
 
 [embedding]
 provider = "disabled"
+
+[mirror]
+root = ".findx/raw"
+
+[bus.bounds]
+source_fs = 1024
+mirror_text = 1024
+
+[extract]
+pool_size = 4
 ```
 
 ## Filesystem cataloging

--- a/findx.toml
+++ b/findx.toml
@@ -13,3 +13,13 @@ extractor_cmd = "docling --to text"
 [embedding]
 provider = "disabled"
 
+[mirror]
+root = ".findx/raw"
+
+[bus.bounds]
+source_fs = 1024
+mirror_text = 1024
+
+[extract]
+pool_size = 4
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,58 @@ pub struct EmbeddingConfig {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+pub struct MirrorConfig {
+    pub root: Utf8PathBuf,
+}
+
+impl Default for MirrorConfig {
+    fn default() -> Self {
+        Self {
+            root: Utf8PathBuf::from(".findx/raw"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BusBounds {
+    pub source_fs: usize,
+    pub mirror_text: usize,
+}
+
+impl Default for BusBounds {
+    fn default() -> Self {
+        Self {
+            source_fs: 1024,
+            mirror_text: 1024,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct BusConfig {
+    pub bounds: BusBounds,
+}
+
+impl Default for BusConfig {
+    fn default() -> Self {
+        Self {
+            bounds: BusBounds::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ExtractConfig {
+    pub pool_size: usize,
+}
+
+impl Default for ExtractConfig {
+    fn default() -> Self {
+        Self { pool_size: 4 }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub db: Utf8PathBuf,
     pub tantivy_index: Utf8PathBuf,
@@ -24,6 +76,12 @@ pub struct Config {
     #[serde(default = "default_extractor_cmd")]
     pub extractor_cmd: String,
     pub embedding: EmbeddingConfig,
+    #[serde(default)]
+    pub mirror: MirrorConfig,
+    #[serde(default)]
+    pub bus: BusConfig,
+    #[serde(default)]
+    pub extract: ExtractConfig,
 }
 
 impl Default for Config {
@@ -48,6 +106,9 @@ impl Default for Config {
             embedding: EmbeddingConfig {
                 provider: "disabled".into(),
             },
+            mirror: MirrorConfig::default(),
+            bus: BusConfig::default(),
+            extract: ExtractConfig::default(),
         }
     }
 }
@@ -62,4 +123,15 @@ impl Config {
 
 fn default_extractor_cmd() -> String {
     "docling --to text".into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_mirror_root() {
+        let cfg = Config::default();
+        assert_eq!(cfg.mirror.root, Utf8PathBuf::from(".findx/raw"));
+    }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,77 @@
+use camino::Utf8PathBuf;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FileMeta {
+    pub file_uid: String,
+    pub path: Utf8PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FileMove {
+    pub file_uid: String,
+    pub from: Utf8PathBuf,
+    pub to: Utf8PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SourceEvent {
+    SyncStarted,
+    SyncDelta {
+        added: Vec<FileMeta>,
+        modified: Vec<FileMeta>,
+        moved: Vec<FileMove>,
+        deleted: Vec<FileMeta>,
+    },
+    FileAdded {
+        file_uid: String,
+        path: Utf8PathBuf,
+    },
+    FileModified {
+        file_uid: String,
+        path: Utf8PathBuf,
+    },
+    FileMoved {
+        file_uid: String,
+        from: Utf8PathBuf,
+        to: Utf8PathBuf,
+    },
+    FileDeleted {
+        file_uid: String,
+        path: Utf8PathBuf,
+    },
+    ExtractionRequested {
+        file_uid: String,
+        content_hash: String,
+    },
+    ExtractionCompleted {
+        file_uid: String,
+        content_hash: String,
+    },
+    ExtractionFailed {
+        file_uid: String,
+        error: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MirrorEvent {
+    MirrorDocUpserted {
+        file_uid: String,
+        content_hash: String,
+    },
+    MirrorDocDeleted {
+        file_uid: String,
+    },
+    MirrorChunkUpserted {
+        chunk_id: String,
+        file_uid: String,
+        order: u64,
+    },
+    MirrorChunkDeleted {
+        chunk_id: String,
+        file_uid: String,
+    },
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -249,6 +249,16 @@ mod tests {
             embedding: crate::config::EmbeddingConfig {
                 provider: "disabled".into(),
             },
+            mirror: crate::config::MirrorConfig {
+                root: Utf8PathBuf::from("raw"),
+            },
+            bus: crate::config::BusConfig {
+                bounds: crate::config::BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: crate::config::ExtractConfig { pool_size: 1 },
         };
 
         cold_scan(&cfg)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cli;
 pub mod config;
 pub mod db;
 pub mod embed;
+pub mod events;
 pub mod extract;
 pub mod fs;
 pub mod index;

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -239,6 +239,16 @@ mod tests {
             embedding: EmbeddingConfig {
                 provider: "disabled".into(),
             },
+            mirror: crate::config::MirrorConfig {
+                root: Utf8PathBuf::from("raw"),
+            },
+            bus: crate::config::BusConfig {
+                bounds: crate::config::BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: crate::config::ExtractConfig { pool_size: 1 },
         };
 
         let conn = db::open(&db_path)?;
@@ -272,6 +282,16 @@ mod tests {
             embedding: EmbeddingConfig {
                 provider: "disabled".into(),
             },
+            mirror: crate::config::MirrorConfig {
+                root: Utf8PathBuf::from("raw"),
+            },
+            bus: crate::config::BusConfig {
+                bounds: crate::config::BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: crate::config::ExtractConfig { pool_size: 1 },
         };
 
         let conn = db::open(&db_path)?;
@@ -307,6 +327,16 @@ mod tests {
             embedding: EmbeddingConfig {
                 provider: "builtin".into(),
             },
+            mirror: crate::config::MirrorConfig {
+                root: Utf8PathBuf::from("raw"),
+            },
+            bus: crate::config::BusConfig {
+                bounds: crate::config::BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: crate::config::ExtractConfig { pool_size: 1 },
         };
 
         std::env::set_var("EMBEDDING_MODEL", "snowflake/snowflake-arctic-embed-xs");
@@ -343,6 +373,16 @@ mod tests {
             embedding: EmbeddingConfig {
                 provider: "builtin".into(),
             },
+            mirror: crate::config::MirrorConfig {
+                root: Utf8PathBuf::from("raw"),
+            },
+            bus: crate::config::BusConfig {
+                bounds: crate::config::BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: crate::config::ExtractConfig { pool_size: 1 },
         };
 
         std::env::set_var("EMBEDDING_MODEL", "snowflake/snowflake-arctic-embed-xs");

--- a/tests/index_formats.rs
+++ b/tests/index_formats.rs
@@ -56,6 +56,16 @@ fn indexes_various_document_types() -> anyhow::Result<()> {
         embedding: EmbeddingConfig {
             provider: "disabled".into(),
         },
+        mirror: findx::config::MirrorConfig {
+            root: root.join("raw"),
+        },
+        bus: findx::config::BusConfig {
+            bounds: findx::config::BusBounds {
+                source_fs: 16,
+                mirror_text: 16,
+            },
+        },
+        extract: findx::config::ExtractConfig { pool_size: 1 },
     };
 
     // Scan filesystem and extract contents


### PR DESCRIPTION
## Summary
- add mirror, bus, and extract configuration sections with defaults
- define SourceEvent and MirrorEvent enums for future pipeline stages
- document new config keys in README and sample config

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab827154d8832c9145667eac74e2f0