### PR TITLE
feat: add extraction worker pool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - `src/events.rs` – event enum definitions
 - `src/metadata.rs` – consumes filesystem events and maintains file metadata
 - `src/util/dashboard.rs` – terminal dashboard for indexing progress
-- Content extraction uses a configurable command (`extractor_cmd`, default `docling --to text`) to populate a `documents` table; plain text files are read directly. The extractor command is parsed with shell-style rules so arguments may be quoted.
+- Content extraction is handled by a worker pool. It reads plain text files directly and runs the configured `extractor_cmd` (default `docling --to text`) for other formats, parsing the command with shell-style rules. Extraction results are emitted as events and jobs are tracked in `extract_jobs`.
 - Tantivy-based BM25 index built under `tantivy_index`
 - Chunk index stored under `tantivy_index/chunks`
 - Tokenization preserves decimals and dotted acronyms so exact section numbers

--- a/README.md
+++ b/README.md
@@ -91,14 +91,15 @@ retries a few times.
 
 ## Content extraction
 
-During indexing, `findx` converts documents to plain text using a
-configurable command (`extractor_cmd`). By default it invokes the
+`findx` converts documents to plain text using a worker pool that runs the
+configurable `extractor_cmd`. By default it invokes the
 [`docling`](https://github.com/docling) CLI with `--to text`. Basic text
 formats like `.txt` or `.md` are read directly without invoking an
 external tool. The command line is parsed with shell-style rules, so
-arguments containing spaces may be quoted.
-Results are stored in a `documents` table with metadata such as language
-and page counts.
+arguments containing spaces may be quoted. Workers listen for
+`ExtractionRequested` events and emit `ExtractionCompleted` events with
+page-aware text for downstream consumers. Jobs are tracked in an
+`extract_jobs` table for traceability.
 
 ## Keyword search
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -72,6 +72,16 @@ pub fn open(path: &Utf8Path) -> Result<Connection> {
           idempotency_key TEXT NOT NULL,
           payload TEXT NOT NULL
         );
+        CREATE TABLE IF NOT EXISTS extract_jobs (
+          id INTEGER PRIMARY KEY,
+          file_uid TEXT NOT NULL,
+          content_hash TEXT NOT NULL,
+          status TEXT NOT NULL,
+          attempt INTEGER NOT NULL DEFAULT 0,
+          started_ts INTEGER,
+          finished_ts INTEGER,
+          error TEXT
+        );
         "#,
     )?;
     Ok(conn)

--- a/src/events.rs
+++ b/src/events.rs
@@ -18,6 +18,14 @@ pub struct FileMove {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct PageBlock {
+    pub page_no: u32,
+    pub text: String,
+    pub start: usize,
+    pub end: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SourceEvent {
     SyncStarted,
@@ -51,6 +59,9 @@ pub enum SourceEvent {
     ExtractionCompleted {
         file_uid: String,
         content_hash: String,
+        extractor: String,
+        extractor_version: String,
+        pages: Vec<PageBlock>,
     },
     ExtractionFailed {
         file_uid: String,

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1,69 +1,146 @@
-//! Document content extraction via external command or builtin reader.
+//! Document content extraction via worker pool and external command.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use std::{fs, process::Command};
 
 use anyhow::{bail, Context, Result};
-use camino::Utf8Path;
-use rusqlite::Connection;
-use tracing::warn;
+use camino::{Utf8Path, Utf8PathBuf};
+use crossbeam_channel::{bounded, Receiver, RecvTimeoutError};
+use rusqlite::{params, Connection};
 
+use crate::bus::EventBus;
 use crate::config::Config;
+use crate::db;
+use crate::events::{PageBlock, SourceEvent};
 
 const PLAINTEXT_EXTS: &[&str] = &["txt", "md", "rs", "toml", "json", "cpp", "c", "h", "hpp"];
 
-/// Extract text from `path` and store results in the DB.
-///
-/// Plain text files are read directly. Other formats are passed to the
-/// configured extractor command which should write extracted text to stdout.
-pub fn extract_file(conn: &Connection, file_id: i64, path: &Utf8Path, cfg: &Config) -> Result<()> {
-    let text = if is_plaintext(path) {
-        match fs::read_to_string(path) {
-            Ok(s) => Some(s),
-            Err(e) => {
-                warn!(%path, error = %e, "failed to read text file");
-                None
-            }
-        }
-    } else if cfg.extractor_cmd.trim().is_empty() {
-        warn!(%path, "no extractor command configured; skipping");
-        None
-    } else {
-        match run_command(&cfg.extractor_cmd, path) {
-            Ok(t) => Some(t),
-            Err(e) => {
-                warn!(%path, error = %e, "extractor command failed");
-                None
-            }
-        }
-    };
+/// Run the extraction worker pool. Workers consume `ExtractionRequested` events
+/// and emit `ExtractionCompleted` or `ExtractionFailed` events.
+pub fn run_pool(bus: EventBus, cfg: &Config, stop: &AtomicBool) -> Result<()> {
+    let rx_events = bus.subscribe_source();
+    let (job_tx, job_rx) = bounded::<(String, String)>(cfg.bus.bounds.source_fs);
 
-    if let Some(text) = text {
-        let now_ts = now();
-        let extractor = if is_plaintext(path) {
-            "builtin".to_string()
-        } else {
-            shell_words::split(&cfg.extractor_cmd)
-                .ok()
-                .and_then(|parts| parts.into_iter().next())
-                .unwrap_or_else(|| "cmd".to_string())
-        };
-        conn.execute(
-            "INSERT OR REPLACE INTO documents (file_id, extractor, extractor_version, lang, page_count, content_md, content_txt, ocr_applied, updated_ts) VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9)",
-            rusqlite::params![
-                file_id,
-                extractor,
-                "",
-                Option::<String>::None,
-                Option::<i64>::None,
-                Option::<String>::None,
-                text,
-                0,
-                now_ts,
-            ],
-        )?;
+    for _ in 0..cfg.extract.pool_size {
+        let rx = job_rx.clone();
+        let bus_w = bus.clone();
+        let cfg_w = cfg.clone();
+        let db_path = cfg.db.clone();
+        std::thread::spawn(move || worker_loop(rx, bus_w, cfg_w, db_path));
     }
 
+    while !stop.load(Ordering::SeqCst) {
+        match rx_events.recv_timeout(Duration::from_millis(100)) {
+            Ok(env) => match env.data {
+                SourceEvent::ExtractionRequested {
+                    file_uid,
+                    content_hash,
+                } => {
+                    let _ = job_tx.send((file_uid, content_hash));
+                }
+                _ => {}
+            },
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+    }
     Ok(())
+}
+
+fn worker_loop(rx: Receiver<(String, String)>, bus: EventBus, cfg: Config, db_path: Utf8PathBuf) {
+    let conn = db::open(&db_path).expect("open db");
+    while let Ok((file_uid, content_hash)) = rx.recv() {
+        let started_ts = now();
+        let _ = conn.execute(
+            "INSERT INTO extract_jobs (file_uid, content_hash, status, attempt, started_ts) VALUES (?1, ?2, 'running', 1, ?3)",
+            params![file_uid, content_hash, started_ts],
+        );
+        match extract_one(&conn, &cfg, &bus, &file_uid, &content_hash) {
+            Ok(()) => {
+                let finished_ts = now();
+                let _ = conn.execute(
+                    "UPDATE extract_jobs SET status='done', finished_ts=?3 WHERE file_uid=?1 AND content_hash=?2",
+                    params![file_uid, content_hash, finished_ts],
+                );
+            }
+            Err(e) => {
+                let finished_ts = now();
+                let _ = conn.execute(
+                    "UPDATE extract_jobs SET status='failed', finished_ts=?3, error=?4 WHERE file_uid=?1 AND content_hash=?2",
+                    params![file_uid, content_hash, finished_ts, e.to_string()],
+                );
+                let _ = bus.publish_source(SourceEvent::ExtractionFailed {
+                    file_uid: file_uid.clone(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+}
+
+fn extract_one(
+    conn: &Connection,
+    cfg: &Config,
+    bus: &EventBus,
+    file_uid: &str,
+    content_hash: &str,
+) -> Result<()> {
+    let path_str: String = conn.query_row(
+        "SELECT realpath FROM files WHERE inode_hint=?1",
+        params![file_uid],
+        |r| r.get(0),
+    )?;
+    let path = Utf8PathBuf::from(path_str);
+    let (extractor, extractor_version, pages) = extract_pages(&path, cfg)?;
+    bus.publish_source(SourceEvent::ExtractionCompleted {
+        file_uid: file_uid.to_string(),
+        content_hash: content_hash.to_string(),
+        extractor,
+        extractor_version,
+        pages,
+    })?;
+    Ok(())
+}
+
+fn extract_pages(path: &Utf8Path, cfg: &Config) -> Result<(String, String, Vec<PageBlock>)> {
+    let plain = is_plaintext(path);
+    let text = if plain {
+        fs::read_to_string(path).with_context(|| format!("read {path}"))?
+    } else if cfg.extractor_cmd.trim().is_empty() {
+        bail!("no extractor_cmd configured");
+    } else {
+        run_command(&cfg.extractor_cmd, path)?
+    };
+    let extractor = if plain {
+        "builtin".to_string()
+    } else {
+        shell_words::split(&cfg.extractor_cmd)
+            .ok()
+            .and_then(|parts| parts.into_iter().next())
+            .unwrap_or_else(|| "cmd".to_string())
+    };
+    let extractor_version = String::new();
+    let pages = split_pages(&text);
+    Ok((extractor, extractor_version, pages))
+}
+
+fn split_pages(text: &str) -> Vec<PageBlock> {
+    let mut pages = Vec::new();
+    let mut offset = 0usize;
+    for (i, p) in text.split('\x0c').enumerate() {
+        let len = p.chars().count();
+        let start = offset;
+        let end = start + len;
+        pages.push(PageBlock {
+            page_no: (i + 1) as u32,
+            text: p.to_string(),
+            start,
+            end,
+        });
+        offset = end + 1; // account for the delimiter
+    }
+    pages
 }
 
 fn is_plaintext(path: &Utf8Path) -> bool {
@@ -91,4 +168,94 @@ fn now() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig};
+    use std::sync::{atomic::AtomicBool, Arc};
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    #[test]
+    fn unicode_pages_preserved() -> Result<()> {
+        let tmp = tempdir()?;
+        let root = Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let file_path = root.join("u.txt");
+        std::fs::write(&file_path, "αβγ\x0cδεζ")?;
+
+        let cfg = crate::config::Config {
+            db: root.join("catalog.db"),
+            tantivy_index: Utf8PathBuf::from("idx"),
+            roots: vec![root.clone()],
+            include: vec!["**/*.txt".into()],
+            exclude: vec![],
+            max_file_size_mb: 200,
+            follow_symlinks: false,
+            commit_interval_secs: 45,
+            guard_interval_secs: 180,
+            default_language: "auto".into(),
+            extractor_cmd: String::new(),
+            embedding: crate::config::EmbeddingConfig {
+                provider: "disabled".into(),
+            },
+            mirror: MirrorConfig {
+                root: Utf8PathBuf::from("raw"),
+            },
+            bus: BusConfig {
+                bounds: BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: ExtractConfig { pool_size: 1 },
+        };
+
+        let conn = db::open(&cfg.db)?;
+        // Insert file metadata so worker can find path
+        conn.execute(
+            "INSERT INTO files (realpath, size, mtime_ns, inode_hint, hash, status, created_ts, updated_ts) VALUES (?1,0,0,?2,?3,'active',0,0)",
+            params![file_path.as_str(), "f1", "h1"],
+        )?;
+        let bus = EventBus::new(&cfg.bus.bounds, Arc::new(std::sync::Mutex::new(conn)));
+        let rx = bus.subscribe_source();
+        let stop = Arc::new(AtomicBool::new(false));
+        let bus_run = bus.clone();
+        let cfg_run = cfg.clone();
+        let stop_run = stop.clone();
+        std::thread::spawn(move || {
+            run_pool(bus_run, &cfg_run, &stop_run).unwrap();
+        });
+        std::thread::sleep(Duration::from_millis(200));
+
+        bus.publish_source(SourceEvent::ExtractionRequested {
+            file_uid: "f1".into(),
+            content_hash: "h1".into(),
+        })?;
+
+        use crossbeam_channel::RecvTimeoutError;
+        let mut pages = None;
+        for _ in 0..50 {
+            match rx.recv_timeout(Duration::from_millis(200)) {
+                Ok(env) => {
+                    if let SourceEvent::ExtractionCompleted { pages: p, .. } = env.data {
+                        pages = Some(p);
+                        break;
+                    }
+                }
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+        stop.store(true, Ordering::SeqCst);
+        let pages = pages.expect("got pages");
+        assert_eq!(pages.len(), 2);
+        assert_eq!(pages[0].text, "αβγ");
+        assert_eq!(pages[0].start, 0);
+        assert_eq!(pages[0].end, 3);
+        assert_eq!(pages[1].start, 4);
+        assert_eq!(pages[1].end, 7);
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- introduce PageBlock structures and extended extraction events
- add extraction worker pool emitting page-aware text and track jobs
- document extraction worker pool in README and AGENTS

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abc1ffe858832c837ace0fc5e3ae4b