### PR TITLE
feat: harden mirror writes and add recovery tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - Hidden files are skipped by default; set `include_hidden=true` to index them. Cloud placeholders marked offline are skipped unless `allow_offline_hydration=true`.
 - The extractor queue is bounded separately with `extract.jobs_bound` (default 2048).
 - Page block `start` and `end` offsets refer to UTF-8 characters.
+- Mirror artifacts (`meta.json`, `chunks.jsonl`) are written atomically
+  using temporary files and renames. Chunk identifiers normalize line
+  endings and strip trailing whitespace to stay stable across platforms.
 - Tantivy-based BM25 index built under `tantivy_index`
 - Chunk index stored under `tantivy_index/chunks`
 - Tokenization preserves decimals and dotted acronyms so exact section numbers

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Extraction output is mirrored under `.findx/raw/<relpath>/` where each
 document directory contains a `meta.json` file and a streaming
 `chunks.jsonl`. The mirror builder emits `MirrorDocUpserted` and
 `MirrorChunkUpserted` events so indexers can work incrementally.
+Mirror files are written atomically via temporary files and renames, and
+chunk identifiers are normalized (line endings, trailing whitespace) to
+remain stable across platforms.
 
 ## Keyword search
 


### PR DESCRIPTION
## Summary
- write mirror metadata and chunk files atomically with tmp+fsync+rename
- normalize chunk hashing for deterministic IDs
- add tests for event ordering, unicode offsets, and crash recovery

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac68e42df0832c94b6727fedc71d88