### PR TITLE
Add database retention and maintenance command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This repository contains `findx`, a Rust CLI for indexing and searching local do
 - `src/metadata.rs` – consumes filesystem events and maintains file metadata
 - `src/mirror/mod.rs` – builds the on-disk text mirror and emits mirror events
 - `src/reconcile.rs` – reconciles the mirror on disk with cataloged files
+- `src/maintain.rs` – runs retention tasks to prune old database records
 - `src/util/dashboard.rs` – terminal dashboard for indexing progress
 - Content extraction is handled by a worker pool. It reads plain text files directly and runs the configured `extractor_cmd` (default `docling --to text`) for other formats, parsing the command with shell-style rules. Extraction results are emitted as events and jobs are tracked in `extract_jobs`.
 - Hidden files are skipped by default; set `include_hidden=true` to index them. Cloud placeholders marked offline are skipped unless `allow_offline_hydration=true`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ mirror_text = 1024
 [extract]
 pool_size = 4
 jobs_bound = 2048
+
+[retention]
+events_days = 14
+jobs_keep_per_file = 3
+jobs_failed_days = 14
+files_tombstone_days = 30
 ```
 
 ## Filesystem cataloging
@@ -117,6 +123,19 @@ remain stable across platforms.
 If mirror artifacts are removed or fall out of sync with the catalog,
 `findx reconcile` will republish extraction jobs for missing files and
 delete orphaned mirror directories.
+
+## Maintenance
+
+Run periodic retention to keep the SQLite catalog from growing without bound:
+
+```bash
+findx maintain
+```
+
+Retention thresholds are configured under `[retention]` in `findx.toml`.
+By default, events older than 14 days are pruned, only the latest three
+extraction jobs per file are kept, failed jobs are dropped after 14 days,
+and files marked deleted are purged after 30 days.
 
 ## Keyword search
 

--- a/findx.toml
+++ b/findx.toml
@@ -26,3 +26,9 @@ mirror_text = 1024
 pool_size = 4
 jobs_bound = 2048
 
+[retention]
+events_days = 14
+jobs_keep_per_file = 3
+jobs_failed_days = 14
+files_tombstone_days = 30
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,6 +54,8 @@ pub enum Command {
     Status,
     #[command(about = "Reconcile mirror and catalog state")]
     Reconcile,
+    #[command(about = "Run database retention tasks")]
+    Maintain,
 }
 
 #[derive(Args, Debug, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,45 @@ fn default_jobs_bound() -> usize {
 }
 
 #[derive(Debug, Deserialize, Clone)]
+pub struct RetentionConfig {
+    #[serde(default = "default_events_days")]
+    pub events_days: u64,
+    #[serde(default = "default_jobs_keep_per_file")]
+    pub jobs_keep_per_file: usize,
+    #[serde(default = "default_jobs_failed_days")]
+    pub jobs_failed_days: u64,
+    #[serde(default = "default_files_tombstone_days")]
+    pub files_tombstone_days: u64,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            events_days: default_events_days(),
+            jobs_keep_per_file: default_jobs_keep_per_file(),
+            jobs_failed_days: default_jobs_failed_days(),
+            files_tombstone_days: default_files_tombstone_days(),
+        }
+    }
+}
+
+fn default_events_days() -> u64 {
+    14
+}
+
+fn default_jobs_keep_per_file() -> usize {
+    3
+}
+
+fn default_jobs_failed_days() -> u64 {
+    14
+}
+
+fn default_files_tombstone_days() -> u64 {
+    30
+}
+
+#[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     pub db: Utf8PathBuf,
     pub tantivy_index: Utf8PathBuf,
@@ -95,6 +134,8 @@ pub struct Config {
     pub bus: BusConfig,
     #[serde(default)]
     pub extract: ExtractConfig,
+    #[serde(default)]
+    pub retention: RetentionConfig,
 }
 
 impl Default for Config {
@@ -124,6 +165,7 @@ impl Default for Config {
             mirror: MirrorConfig::default(),
             bus: BusConfig::default(),
             extract: ExtractConfig::default(),
+            retention: RetentionConfig::default(),
         }
     }
 }
@@ -148,5 +190,14 @@ mod tests {
     fn default_mirror_root() {
         let cfg = Config::default();
         assert_eq!(cfg.mirror.root, Utf8PathBuf::from(".findx/raw"));
+    }
+
+    #[test]
+    fn default_retention() {
+        let cfg = Config::default();
+        assert_eq!(cfg.retention.events_days, 14);
+        assert_eq!(cfg.retention.jobs_keep_per_file, 3);
+        assert_eq!(cfg.retention.jobs_failed_days, 14);
+        assert_eq!(cfg.retention.files_tombstone_days, 30);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,6 +15,7 @@ pub fn open(path: &Utf8Path) -> Result<Connection> {
     conn.execute_batch(
         r#"
         PRAGMA journal_mode=WAL;
+        PRAGMA wal_autocheckpoint=1000;
         CREATE TABLE IF NOT EXISTS files (
           id INTEGER PRIMARY KEY,
           realpath TEXT UNIQUE NOT NULL,

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -213,7 +213,7 @@ fn now() -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig};
+    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig, RetentionConfig};
     use std::sync::{atomic::AtomicBool, Arc};
     use std::time::Duration;
     use tempfile::tempdir;
@@ -255,6 +255,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         let conn = db::open(&cfg.db)?;
@@ -340,6 +341,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         let conn = db::open(&cfg.db)?;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -286,7 +286,7 @@ mod tests {
     use crate::db;
     use crate::{
         bus::EventBus,
-        config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig},
+        config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig, RetentionConfig},
     };
     use std::sync::{atomic::AtomicBool, Arc, Mutex};
     use std::time::Duration;
@@ -329,6 +329,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         let conn = db::open(&cfg.db)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod events;
 mod extract;
 mod fs;
 mod index;
+mod maintain;
 mod metadata;
 mod mirror;
 mod reconcile;
@@ -208,6 +209,10 @@ async fn main() -> Result<()> {
         Command::Reconcile => {
             tracing::info!(?cfg, "reconcile");
             reconcile::run(&bus, &cfg)?;
+        }
+        Command::Maintain => {
+            tracing::info!(?cfg, "maintain");
+            maintain::run(&cfg)?;
         }
     }
 

--- a/src/maintain.rs
+++ b/src/maintain.rs
@@ -1,0 +1,209 @@
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+use crate::config::Config;
+use crate::db;
+
+/// Run database retention tasks according to configuration.
+pub fn run(cfg: &Config) -> Result<()> {
+    let conn = db::open(&cfg.db)?;
+    let now = now();
+    prune_events(&conn, now, cfg.retention.events_days)?;
+    prune_extract_jobs(
+        &conn,
+        now,
+        cfg.retention.jobs_keep_per_file,
+        cfg.retention.jobs_failed_days,
+    )?;
+    prune_files(&conn, now, cfg.retention.files_tombstone_days)?;
+    clean_orphans(&conn, cfg)?;
+    vacuum_if_needed(&conn)?;
+    Ok(())
+}
+
+fn prune_events(conn: &Connection, now: i64, days: u64) -> Result<()> {
+    let cutoff = now - (days as i64) * 86_400;
+    conn.execute("DELETE FROM events WHERE ts < ?1", params![cutoff])?;
+    Ok(())
+}
+
+fn prune_extract_jobs(
+    conn: &Connection,
+    now: i64,
+    keep_per_file: usize,
+    failed_days: u64,
+) -> Result<()> {
+    let cutoff_failed = now - (failed_days as i64) * 86_400;
+    conn.execute(
+        "DELETE FROM extract_jobs WHERE status='failed' AND finished_ts IS NOT NULL AND finished_ts < ?1",
+        params![cutoff_failed],
+    )?;
+    conn.execute(
+        "DELETE FROM extract_jobs WHERE id IN (
+            SELECT id FROM (
+                SELECT id, ROW_NUMBER() OVER (PARTITION BY file_uid ORDER BY id DESC) AS rn
+                FROM extract_jobs
+            ) WHERE rn > ?1
+        )",
+        params![keep_per_file],
+    )?;
+    Ok(())
+}
+
+fn prune_files(conn: &Connection, now: i64, days: u64) -> Result<()> {
+    let cutoff = now - (days as i64) * 86_400;
+    conn.execute(
+        "DELETE FROM files WHERE status!='active' AND updated_ts < ?1",
+        params![cutoff],
+    )?;
+    Ok(())
+}
+
+fn clean_orphans(conn: &Connection, cfg: &Config) -> Result<()> {
+    // Remove mirror artifacts whose source file no longer exists.
+    let mut stmt = conn.prepare(
+        "SELECT file_uid, path FROM mirror_docs WHERE file_uid NOT IN (SELECT inode_hint FROM files)",
+    )?;
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+    for row in rows {
+        let (uid, path) = row?;
+        let dir = cfg.mirror.root.join(&path);
+        let _ = fs::remove_dir_all(&dir);
+        conn.execute("DELETE FROM mirror_chunks WHERE file_uid=?1", params![&uid])?;
+        conn.execute("DELETE FROM mirror_docs WHERE file_uid=?1", params![&uid])?;
+    }
+    // Remove mirror chunks without parent docs.
+    conn.execute(
+        "DELETE FROM mirror_chunks WHERE file_uid NOT IN (SELECT file_uid FROM mirror_docs)",
+        [],
+    )?;
+    Ok(())
+}
+
+fn vacuum_if_needed(conn: &Connection) -> Result<()> {
+    let page_count: i64 = conn.query_row("PRAGMA page_count;", [], |r| r.get(0))?;
+    let free: i64 = conn.query_row("PRAGMA freelist_count;", [], |r| r.get(0))?;
+    if free > 1000 && free * 10 > page_count {
+        conn.execute_batch("VACUUM;")?;
+    }
+    Ok(())
+}
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig, RetentionConfig};
+    use tempfile::tempdir;
+
+    fn base_config(root: &camino::Utf8Path) -> Config {
+        Config {
+            db: root.join("catalog.db"),
+            tantivy_index: camino::Utf8PathBuf::from("idx"),
+            roots: vec![root.to_path_buf()],
+            include: vec![],
+            exclude: vec![],
+            max_file_size_mb: 200,
+            follow_symlinks: false,
+            include_hidden: false,
+            allow_offline_hydration: false,
+            commit_interval_secs: 45,
+            guard_interval_secs: 180,
+            default_language: "auto".into(),
+            extractor_cmd: String::new(),
+            embedding: crate::config::EmbeddingConfig {
+                provider: "disabled".into(),
+            },
+            mirror: MirrorConfig {
+                root: root.join("raw"),
+            },
+            bus: BusConfig {
+                bounds: BusBounds {
+                    source_fs: 16,
+                    mirror_text: 16,
+                },
+            },
+            extract: ExtractConfig {
+                pool_size: 1,
+                jobs_bound: 16,
+            },
+            retention: RetentionConfig::default(),
+        }
+    }
+
+    #[test]
+    fn prunes_old_rows() -> Result<()> {
+        let tmp = tempdir()?;
+        let root = camino::Utf8PathBuf::from_path_buf(tmp.path().to_path_buf()).unwrap();
+        let mut cfg = base_config(&root);
+        cfg.retention.jobs_keep_per_file = 1;
+        fs::create_dir_all(&cfg.mirror.root)?;
+        let conn = db::open(&cfg.db)?;
+        // old event
+        conn.execute(
+            "INSERT INTO events (ts, topic, type, idempotency_key, payload) VALUES (0,'t','t','k','{}')",
+            [],
+        )?;
+        // new event
+        conn.execute(
+            "INSERT INTO events (ts, topic, type, idempotency_key, payload) VALUES (?1,'t','t','k2','{}')",
+            params![now()],
+        )?;
+        // extract jobs
+        conn.execute(
+            "INSERT INTO extract_jobs (file_uid, content_hash, status, attempt, started_ts, finished_ts) VALUES ('f1','h','failed',0,0,0)",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO extract_jobs (file_uid, content_hash, status, attempt, started_ts, finished_ts) VALUES ('f1','h2','done',0,0,0)",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO extract_jobs (file_uid, content_hash, status, attempt, started_ts, finished_ts) VALUES ('f1','h3','done',0,0,0)",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO extract_jobs (file_uid, content_hash, status, attempt, started_ts, finished_ts) VALUES ('f1','h4','done',0,0,0)",
+            [],
+        )?;
+        // tombstoned file
+        conn.execute(
+            "INSERT INTO files (realpath,size,mtime_ns,fast_sig,is_offline,attrs,inode_hint,status,created_ts,updated_ts) VALUES ('a',0,0,'',0,0,'uid1','deleted',0,0)",
+            [],
+        )?;
+        // orphan mirror doc
+        let dir = cfg.mirror.root.join("a");
+        fs::create_dir_all(&dir)?;
+        conn.execute(
+            "INSERT INTO mirror_docs (file_uid, content_hash, path, updated_ts) VALUES ('uid2','h','a',0)",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO mirror_chunks (chunk_id, file_uid, ord) VALUES ('c1','uid2',0)",
+            [],
+        )?;
+        drop(conn);
+        run(&cfg)?;
+        let conn = db::open(&cfg.db)?;
+        let ev_count: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))?;
+        assert_eq!(ev_count, 1);
+        let job_count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM extract_jobs", [], |r| r.get(0))?;
+        assert_eq!(job_count, 1);
+        let file_count: i64 = conn.query_row("SELECT COUNT(*) FROM files", [], |r| r.get(0))?;
+        assert_eq!(file_count, 0);
+        let md_count: i64 = conn.query_row("SELECT COUNT(*) FROM mirror_docs", [], |r| r.get(0))?;
+        assert_eq!(md_count, 0);
+        assert!(!dir.exists());
+        Ok(())
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -152,7 +152,7 @@ fn now() -> i64 {
 mod tests {
     use super::*;
     use crate::bus::EventBus;
-    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig};
+    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig, RetentionConfig};
     use camino::Utf8PathBuf;
     use std::sync::{
         atomic::{AtomicBool, Ordering},
@@ -197,6 +197,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         let conn = db::open(&cfg.db)?;

--- a/src/mirror/mod.rs
+++ b/src/mirror/mod.rs
@@ -360,7 +360,7 @@ fn now() -> i64 {
 mod tests {
     use super::*;
     use crate::bus::EventBus;
-    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig};
+    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig, RetentionConfig};
     use std::collections::HashSet;
     use std::fs;
     use std::sync::atomic::AtomicBool;
@@ -400,6 +400,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 8,
             },
+            retention: RetentionConfig::default(),
         };
         let conn = db::open(&cfg.db)?;
         conn.execute(
@@ -491,6 +492,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 8,
             },
+            retention: RetentionConfig::default(),
         };
         let conn = db::open(&cfg.db)?;
         conn.execute(
@@ -561,6 +563,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 8,
             },
+            retention: RetentionConfig::default(),
         };
         let conn = db::open(&cfg.db)?;
         conn.execute(

--- a/src/reconcile.rs
+++ b/src/reconcile.rs
@@ -87,7 +87,7 @@ fn relativize(path: &Utf8Path, roots: &[Utf8PathBuf]) -> Utf8PathBuf {
 mod tests {
     use super::*;
     use crate::bus::EventBus;
-    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig};
+    use crate::config::{BusBounds, BusConfig, ExtractConfig, MirrorConfig, RetentionConfig};
     use crossbeam_channel::RecvTimeoutError;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -124,6 +124,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         }
     }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -214,7 +214,7 @@ mod tests {
     use camino::Utf8PathBuf;
     use tempfile::tempdir;
 
-    use crate::config::{Config, EmbeddingConfig};
+    use crate::config::{Config, EmbeddingConfig, RetentionConfig};
     use crate::db;
     use rusqlite::params;
 
@@ -254,6 +254,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         let conn = db::open(&db_path)?;
@@ -302,6 +303,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         let conn = db::open(&db_path)?;
@@ -352,6 +354,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         std::env::set_var("EMBEDDING_MODEL", "snowflake/snowflake-arctic-embed-xs");
@@ -403,6 +406,7 @@ mod tests {
                 pool_size: 1,
                 jobs_bound: 16,
             },
+            retention: RetentionConfig::default(),
         };
 
         std::env::set_var("EMBEDDING_MODEL", "snowflake/snowflake-arctic-embed-xs");

--- a/tests/index_formats.rs
+++ b/tests/index_formats.rs
@@ -2,7 +2,7 @@ use camino::Utf8PathBuf;
 use std::{fs, process::Command};
 use tempfile::tempdir;
 
-use findx::config::{Config, EmbeddingConfig};
+use findx::config::{Config, EmbeddingConfig, RetentionConfig};
 use findx::{bus::EventBus, fs as findx_fs, index, metadata, search};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -76,6 +76,7 @@ fn indexes_various_document_types() -> anyhow::Result<()> {
             pool_size: 1,
             jobs_bound: 16,
         },
+        retention: RetentionConfig::default(),
     };
 
     // Scan filesystem and extract contents (legacy path pending new pipeline)


### PR DESCRIPTION
## Summary
- add retention config and `findx maintain` command
- implement database cleanup task pruning old events, jobs, and files
- document retention settings and maintenance usage

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac763783d0832c90a79f35ad87e25d