### PR TITLE
Derive crate version from git tags

### DIFF
--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SHA=$(git rev-parse --short HEAD)
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+  VERSION="${GITHUB_REF_NAME}"
+  DESCRIBE="${GITHUB_REF_NAME}"
+else
+  DESCRIBE="$(git describe --tags --always --dirty)"
+  VERSION="${DESCRIBE}"
+fi
+{
+  echo "version=${VERSION}"
+  echo "describe=${DESCRIBE}"
+  echo "sha=${SHA}"
+  echo "date=${DATE}"
+} >> "${GITHUB_OUTPUT:-/dev/stdout}"
+
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  MAJOR="${BASH_REMATCH[1]}"
+  MINOR="${BASH_REMATCH[2]}"
+  PATCH="${BASH_REMATCH[3]}"
+  {
+    echo "major=${MAJOR}"
+    echo "minor=${MINOR}"
+    echo "patch=${PATCH}"
+    echo "is_clean_release=true"
+  } >> "${GITHUB_OUTPUT:-/dev/stdout}"
+else
+  echo "is_clean_release=false" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,31 +35,7 @@ jobs:
       - name: Compute version metadata
         id: meta
         shell: bash
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-            DESCRIBE="${GITHUB_REF_NAME}"
-          else
-            DESCRIBE="$(git describe --tags --always --dirty)"
-            VERSION="${DESCRIBE}"
-          fi
-          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
-          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
-          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
-          echo "date=${DATE}"         >> $GITHUB_OUTPUT
-          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            MAJOR="${BASH_REMATCH[1]}"
-            MINOR="${BASH_REMATCH[2]}"
-            PATCH="${BASH_REMATCH[3]}"
-            echo "major=${MAJOR}" >> $GITHUB_OUTPUT
-            echo "minor=${MINOR}" >> $GITHUB_OUTPUT
-            echo "patch=${PATCH}" >> $GITHUB_OUTPUT
-            echo "is_clean_release=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_clean_release=false" >> $GITHUB_OUTPUT
-          fi
+        run: .github/scripts/version.sh
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
@@ -104,6 +80,8 @@ jobs:
           platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            FINDX_VERSION=${{ steps.meta.outputs.version }}
 
 
       - name: Sign the published Docker image ( ${{ matrix.variant.name }} )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,7 @@ jobs:
       - name: Compute version metadata
         id: meta
         shell: bash
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-            DESCRIBE="${GITHUB_REF_NAME}"
-          else
-            DESCRIBE="$(git describe --tags --always --dirty)"
-            VERSION="${DESCRIBE}"
-          fi
-          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
-          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
-          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
-          echo "date=${DATE}"         >> $GITHUB_OUTPUT
+        run: .github/scripts/version.sh
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Compute version metadata
+      id: meta
+      shell: bash
+      run: |
+        if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+          VERSION="${GITHUB_REF_NAME}"
+        else
+          VERSION="$(git describe --tags --always --dirty)"
+        fi
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
     - name: Build
+      env:
+        FINDX_VERSION: ${{ steps.meta.outputs.version }}
       run: cargo build --verbose
     - name: Run tests
+      env:
+        FINDX_VERSION: ${{ steps.meta.outputs.version }}
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,13 +19,7 @@ jobs:
     - name: Compute version metadata
       id: meta
       shell: bash
-      run: |
-        if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-          VERSION="${GITHUB_REF_NAME}"
-        else
-          VERSION="$(git describe --tags --always --dirty)"
-        fi
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      run: .github/scripts/version.sh
     - name: Build
       env:
         FINDX_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,20 +27,7 @@ jobs:
       - name: Compute version metadata
         id: meta
         shell: bash
-        run: |
-          SHA=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            VERSION="${GITHUB_REF_NAME}"
-            DESCRIBE="${GITHUB_REF_NAME}"
-          else
-            DESCRIBE="$(git describe --tags --always --dirty)"
-            VERSION="${DESCRIBE}"
-          fi
-          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
-          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
-          echo "sha=${SHA}"           >> $GITHUB_OUTPUT
-          echo "date=${DATE}"         >> $GITHUB_OUTPUT
+        run: .github/scripts/version.sh
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ All new or modified features should include unit tests.
 Snapshot artifacts for `main` come from `.github/workflows/snapshot.yml`.
 Releases are published with `.github/workflows/release.yml`, which builds and uploads binaries for Linux, macOS, and Windows when a tag is pushed.
 `Cargo.toml` intentionally omits a package version; workflows set `FINDX_VERSION` from the current git tag.
+Shared script `.github/scripts/version.sh` computes tag-based version metadata for builds, including Docker images.
 
 ## Documentation
 Keep documentation current. Update `README.md` and this `AGENTS.md` whenever project behavior or structure changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ All new or modified features should include unit tests.
 
 Snapshot artifacts for `main` come from `.github/workflows/snapshot.yml`.
 Releases are published with `.github/workflows/release.yml`, which builds and uploads binaries for Linux, macOS, and Windows when a tag is pushed.
+`Cargo.toml` intentionally omits a package version; workflows set `FINDX_VERSION` from the current git tag.
 
 ## Documentation
 Keep documentation current. Update `README.md` and this `AGENTS.md` whenever project behavior or structure changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "findx"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "findx"
-version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ cargo build
 
 Prebuilt binaries for Linux, macOS, and Windows are available on the [GitHub Releases](https://github.com/gaspardpetit/findx/releases) page.
 These binaries embed the release tag; verify with `findx --version`.
+Development builds derive their version from the current git tag and `Cargo.toml` intentionally omits a package version.
 
 Snapshot artifacts for the `main` branch are published by the `snapshot` workflow.
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Snapshot artifacts for the `main` branch are published by the `snapshot` workflo
 
 ## Docker
 
-A published container image can run `findx` against a mounted directory. Bind a host path to `/data` and pass your config.
+A published container image can run `findx` against a mounted directory. Bind a host path to `/data` and pass your config. Images embed the current git tag via the `FINDX_VERSION` build argument.
 
 ### Index and query
 

--- a/deploy/Dockerfile.bundle
+++ b/deploy/Dockerfile.bundle
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.7
 FROM rust:1.88 AS rust-builder
 
+ARG FINDX_VERSION=0.0.0
+
 # Install clang for C compilation of sqlite3.c
 RUN apt-get update \
  && apt-get install -y --no-install-recommends clang pkg-config \
@@ -10,6 +12,7 @@ RUN apt-get update \
 ENV CC=clang \
     CXX=clang++ \
     CFLAGS="-O2"
+ENV FINDX_VERSION=${FINDX_VERSION}
 
 WORKDIR /usr/src/findx
 


### PR DESCRIPTION
## Summary
- rely on git tags for runtime version metadata
- document that Cargo.toml intentionally omits a package version
- propagate tag-based versioning to the main CI workflow

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac77a719e0832c8934571da58b95f7