### PR TITLE
chore: automate version stamping

### DIFF
--- a/.github/scripts/version.sh
+++ b/.github/scripts/version.sh
@@ -1,23 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SHA=$(git rev-parse --short HEAD)
-DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
-  VERSION="${GITHUB_REF_NAME}"
-  DESCRIBE="${GITHUB_REF_NAME}"
+# Optional override for callers that need a specific version string
+if [[ -n "${OVERRIDE_VERSION:-}" ]]; then
+  VERSION="${OVERRIDE_VERSION}"
+  DESCRIBE="${VERSION}"
 else
-  DESCRIBE="$(git describe --tags --always --dirty)"
-  VERSION="${DESCRIBE}"
+  SHORT_SHA=$(git rev-parse --short=8 HEAD)
+  DATE_RFC3339=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  DATE_YMD=$(date -u +%Y%m%d)
+  if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+    TAG="${GITHUB_REF_NAME}"
+  else
+    TAG="$(git describe --tags --abbrev=0)"
+  fi
+  BASE="${TAG#v}"
+  if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+    VERSION="${BASE}"
+  else
+    VERSION="${BASE}-dev.${DATE_YMD}-${SHORT_SHA}"
+  fi
+  DESCRIBE="${VERSION}"
+  SHA="${SHORT_SHA}"
+  DATE="${DATE_RFC3339}"
 fi
+
+# Write outputs
 {
   echo "version=${VERSION}"
   echo "describe=${DESCRIBE}"
-  echo "sha=${SHA}"
-  echo "date=${DATE}"
+  [[ -n "${SHA:-}" ]] && echo "sha=${SHA}"
+  [[ -n "${DATE:-}" ]] && echo "date=${DATE}"
 } >> "${GITHUB_OUTPUT:-/dev/stdout}"
 
-if [[ "${GITHUB_REF_TYPE:-}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+# Detect semantic version when building tagged releases
+if [[ "${GITHUB_REF_TYPE:-}" == "tag" && "${GITHUB_REF_NAME:-}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
   MAJOR="${BASH_REMATCH[1]}"
   MINOR="${BASH_REMATCH[2]}"
   PATCH="${BASH_REMATCH[3]}"
@@ -29,4 +46,21 @@ if [[ "${GITHUB_REF_TYPE:-}" == "tag" && "${GITHUB_REF_NAME}" =~ ^v([0-9]+)\.([0
   } >> "${GITHUB_OUTPUT:-/dev/stdout}"
 else
   echo "is_clean_release=false" >> "${GITHUB_OUTPUT:-/dev/stdout}"
+fi
+
+update_cargo_version() {
+  local ver="$1"
+  local sed_in=("-i")
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed_in=("-i" "")
+  fi
+  if grep -q '^version = ' Cargo.toml; then
+    sed "${sed_in[@]}" -E "s/^version = \".*\"/version = \"${ver}\"/" Cargo.toml
+  else
+    sed "${sed_in[@]}" -E "0,/^name = \"findx\"/s//name = \"findx\"\nversion = \"${ver}\"/" Cargo.toml
+  fi
+}
+
+if [[ "${UPDATE_CARGO_TOML:-}" == "1" ]]; then
+  update_cargo_version "${VERSION}"
 fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Compute version metadata
         id: meta
         shell: bash
+        env:
+          UPDATE_CARGO_TOML: "1"
         run: .github/scripts/version.sh
 
       - name: Install cosign

--- a/.github/workflows/post-release-version.yml
+++ b/.github/workflows/post-release-version.yml
@@ -1,0 +1,26 @@
+name: post-release-version
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set dev version in Cargo.toml
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}-dev"
+          UPDATE_CARGO_TOML=1 OVERRIDE_VERSION="$VERSION" .github/scripts/version.sh
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -am "chore: start $VERSION"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Compute version metadata
         id: meta
         shell: bash
+        env:
+          UPDATE_CARGO_TOML: "1"
         run: .github/scripts/version.sh
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Compute version metadata
         id: meta
         shell: bash
+        env:
+          UPDATE_CARGO_TOML: "1"
         run: .github/scripts/version.sh
 
       - uses: actions-rs/toolchain@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,7 @@ All new or modified features should include unit tests.
 
 Snapshot artifacts for `main` come from `.github/workflows/snapshot.yml`.
 Releases are published with `.github/workflows/release.yml`, which builds and uploads binaries for Linux, macOS, and Windows when a tag is pushed.
-`Cargo.toml` intentionally omits a package version; workflows set `FINDX_VERSION` from the current git tag.
-Shared script `.github/scripts/version.sh` computes tag-based version metadata for builds, including Docker images.
+`Cargo.toml` tracks the last release version with a `-dev` suffix. The shared `.github/scripts/version.sh` updates it and derives `FINDX_VERSION` for builds, including Docker images.
 
 ## Documentation
 Keep documentation current. Update `README.md` and this `AGENTS.md` whenever project behavior or structure changes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "findx"
+version = "0.2.3-dev"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ cargo build
 
 Prebuilt binaries for Linux, macOS, and Windows are available on the [GitHub Releases](https://github.com/gaspardpetit/findx/releases) page.
 These binaries embed the release tag; verify with `findx --version`.
-Development builds derive their version from the current git tag and `Cargo.toml` intentionally omits a package version.
+`Cargo.toml` tracks the last release as `<tag>-dev`. Snapshot builds append the build date and commit hash (e.g. `0.2.3-dev.20240101-abcdef12`) while releases use the plain tag version.
 
 Snapshot artifacts for the `main` branch are published by the `snapshot` workflow.
 


### PR DESCRIPTION
## Summary
- derive and set cargo version during snapshot and release builds
- update workflows to stamp versions and add post-release dev bump
- document new versioning scheme

## Testing
- `cargo fmt --all`
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1f5d9bf0832cb73ffcba005c9015